### PR TITLE
Update plugin to work with Godot 4 Beta 13+

### DIFF
--- a/addons/gdshell/scripts/gdshell_command.gd
+++ b/addons/gdshell/scripts/gdshell_command.gd
@@ -1,7 +1,6 @@
+@icon("res://addons/gdshell/icon.pg")
 class_name GDShellCommand
 extends Node
-@icon("res://addons/gdshell/icon.png")
-
 
 signal command_end
 

--- a/addons/gdshell/scripts/gdshell_command_db.gd
+++ b/addons/gdshell/scripts/gdshell_command_db.gd
@@ -1,6 +1,6 @@
+@icon("res://addons/gdshell/icon.png")
 class_name GDShellCommandDB
 extends RefCounted
-@icon("res://addons/gdshell/icon.png")
 
 
 var _commands: Dictionary = {}

--- a/addons/gdshell/scripts/gdshell_command_parser.gd
+++ b/addons/gdshell/scripts/gdshell_command_parser.gd
@@ -1,6 +1,6 @@
+@icon("res://addons/gdshell/icon.png")
 class_name GDShellCommandParser
 extends RefCounted
-@icon("res://addons/gdshell/icon.png")
 
 
 enum TokenType {

--- a/addons/gdshell/scripts/gdshell_command_runner.gd
+++ b/addons/gdshell/scripts/gdshell_command_runner.gd
@@ -1,6 +1,6 @@
+@icon("res://addons/gdshell/icon.png")
 class_name GDShellCommandRunner
 extends Node
-@icon("res://addons/gdshell/icon.png")
 
 
 # Command execution flags

--- a/addons/gdshell/scripts/gdshell_main.gd
+++ b/addons/gdshell/scripts/gdshell_main.gd
@@ -1,6 +1,6 @@
+@icon("res://addons/gdshell/icon.png")
 class_name GDShellMain
 extends Node
-@icon("res://addons/gdshell/icon.png")
 
 
 signal _input_submitted(input: String)

--- a/addons/gdshell/scripts/gdshell_ui_handler.gd
+++ b/addons/gdshell/scripts/gdshell_ui_handler.gd
@@ -1,6 +1,6 @@
+@icon("res://addons/gdshell/icon.png")
 class_name GDShellUIHandler
 extends Control
-@icon("res://addons/gdshell/icon.png")
 
 
 signal _input_requested(output: String)


### PR DESCRIPTION
Godot 4 Beta 13 changed the required order of @icon in relation to @class.  Annotations must appear before the thing they annotate.

This corrects the order resolving the issue for GD4 Beta 13, as this is the reverse of the required ordering for GD4 Beta 12 applying this means that the plugin will no longer work for installs of <= GD4 Beta 12,

See the following issues for more details:
- https://github.com/godotengine/godot/issues/71592
- https://github.com/godotengine/godot-docs/issues/6629

The PR that introduces the change:
- https://github.com/godotengine/godot/pull/67774