### PR TITLE
Add crude autocomplete and history

### DIFF
--- a/addons/gdshell/scripts/gdshell_main.gd
+++ b/addons/gdshell/scripts/gdshell_main.gd
@@ -93,6 +93,11 @@ func _request_input_from_ui_handler(out: String = "") -> String:
 func _request_output_from_ui_handler(output: String, append_new_line: bool) -> void:
 	ui_handler._output_requested.emit(output, append_new_line)
 
+func _autocomplete(input: String) -> String:
+	var matches = command_db.get_all_command_names().filter(func(str: String): return str.begins_with(input))
+	if matches.size() > 0:
+		return matches[0]
+	return input
 
 func _submit_input(input: String) -> void:
 	if _is_command_awaiting_input:

--- a/addons/gdshell/scripts/gdshell_main.gd
+++ b/addons/gdshell/scripts/gdshell_main.gd
@@ -35,7 +35,7 @@ func setup_with_default_values() -> void:
 	setup_command_runner()
 	setup_command_db(COMMAND_DIR_PATH)
 	setup_ui_handler(load_ui_handler_from_path(UI_HANDLER_PATH), true)
-	
+
 	if execute_autorun_on_startup:
 		execute_autorun()
 
@@ -56,7 +56,7 @@ func setup_ui_handler(handler: GDShellUIHandler, add_as_child: bool = true) -> v
 	ui_handler = handler
 	ui_handler._PARENT_GDSHELL = self
 	ui_handler.set_visible(false)
-	
+
 	if add_as_child:
 		var canvas_layer: CanvasLayer = CanvasLayer.new()
 		canvas_layer.layer = GDSHELL_CANVAS_LAYER
@@ -93,19 +93,13 @@ func _request_input_from_ui_handler(out: String = "") -> String:
 func _request_output_from_ui_handler(output: String, append_new_line: bool) -> void:
 	ui_handler._output_requested.emit(output, append_new_line)
 
-func _autocomplete(input: String) -> String:
-	var matches = command_db.get_all_command_names().filter(func(str: String): return str.begins_with(input))
-	if matches.size() > 0:
-		return matches[0]
-	return input
-
 func _submit_input(input: String) -> void:
 	if _is_command_awaiting_input:
 		_is_command_awaiting_input = false
 		_request_output_from_ui_handler(input, true)
 		_input_submitted.emit(input)
 		return
-	
+
 	_input_buffer += input
 	var command_sequence: Dictionary = GDShellCommandParser.parse(_input_buffer, command_db)
 	match command_sequence["status"]:

--- a/addons/gdshell/scripts/gdshell_ui_handler.gd
+++ b/addons/gdshell/scripts/gdshell_ui_handler.gd
@@ -12,6 +12,8 @@ var _PARENT_GDSHELL: GDShellMain
 func submit_input(input: String) -> void:
 	_PARENT_GDSHELL._submit_input(input)
 
+func autocomplete(input: String) -> String:
+	return _PARENT_GDSHELL._autocomplete(input)
 
 func toggle_visible() -> void:
 	visible = not visible

--- a/addons/gdshell/scripts/gdshell_ui_handler.gd
+++ b/addons/gdshell/scripts/gdshell_ui_handler.gd
@@ -8,12 +8,35 @@ signal _output_requested(output: String, append_new_line: bool)
 
 var _PARENT_GDSHELL: GDShellMain
 
+var history: Array = []
+var hist_index = -1
 
 func submit_input(input: String) -> void:
 	_PARENT_GDSHELL._submit_input(input)
+	history.push_front(input)
+	history_reset_index()
 
 func autocomplete(input: String) -> String:
-	return _PARENT_GDSHELL._autocomplete(input)
+	var all_commands = _PARENT_GDSHELL.command_db.get_all_command_names()
+	var matches = all_commands.filter(func(str: String): return str.begins_with(input))
+	if matches.size() > 0:
+		return matches[0]
+	return input
+	
+func history_get_next() -> String:
+	if (history.size() == 0):
+		return ""
+	hist_index = clamp(hist_index + 1, 0, history.size() - 1)
+	return history[hist_index]
+	
+func history_get_previous() -> String:
+	if (history.size() == 0):
+		return ""
+	hist_index = clamp(hist_index - 1, 0, history.size() - 1)
+	return history[hist_index]
+	
+func history_reset_index() -> void:
+	hist_index = -1
 
 func toggle_visible() -> void:
 	visible = not visible

--- a/addons/gdshell/ui/default_ui/default_ui.gd
+++ b/addons/gdshell/ui/default_ui/default_ui.gd
@@ -105,6 +105,8 @@ func _handle_output(output: String, append_new_line: bool = true) -> void:
 
 func _on_input_line_edit_text_submitted(input: String) -> void:
 	input_line_edit.clear()
+	history.push_front(input)
+	hist_index = -1
 	if _is_input_requested:
 		submit_input(input)
 		_is_input_requested = false
@@ -123,3 +125,23 @@ func _on_visibility_changed() -> void:
 		input_line_edit.call_deferred(&"grab_focus")
 	else:
 		input_line_edit.release_focus()
+
+var history: Array = []
+var hist_index = -1
+
+func set_line_edit_caret_to_end():
+	input_line_edit.caret_column = input_line_edit.text.length()
+
+func _on_input_line_edit_gui_input(event):
+	if (event is InputEventKey and event.pressed):
+		if event.keycode == KEY_TAB:
+			input_line_edit.text = autocomplete(input_line_edit.text)
+			set_line_edit_caret_to_end.call_deferred()
+		elif input_line_edit.caret_column == 0 and history.size() > 0:
+			if event.keycode == KEY_UP:
+				hist_index = clamp(hist_index + 1, 0, history.size() - 1)
+				input_line_edit.text = history[hist_index]
+			elif event.keycode == KEY_DOWN:
+				hist_index = clamp(hist_index - 1, 0, history.size() - 1)
+				input_line_edit.text = history[hist_index]
+		

--- a/addons/gdshell/ui/default_ui/default_ui.gd
+++ b/addons/gdshell/ui/default_ui/default_ui.gd
@@ -139,12 +139,12 @@ func _on_input_line_edit_gui_input(event):
 		if event.keycode == KEY_TAB:
 			input_line_edit.text = autocomplete(text_before_caret())
 			set_line_edit_caret_to_end.call_deferred()
-	elif event.keycode == KEY_UP:
-		input_line_edit.text = history_get_next()
-		set_line_edit_caret_to_end.call_deferred()
-	elif event.keycode == KEY_DOWN:
-		input_line_edit.text = history_get_previous()
-		set_line_edit_caret_to_end.call_deferred()
+		elif event.keycode == KEY_UP:
+			input_line_edit.text = history_get_next()
+			set_line_edit_caret_to_end.call_deferred()
+		elif event.keycode == KEY_DOWN:
+			input_line_edit.text = history_get_previous()
+			set_line_edit_caret_to_end.call_deferred()
 		else:
 			history_reset_index()
 		

--- a/addons/gdshell/ui/default_ui/default_ui.gd
+++ b/addons/gdshell/ui/default_ui/default_ui.gd
@@ -139,13 +139,12 @@ func _on_input_line_edit_gui_input(event):
 		if event.keycode == KEY_TAB:
 			input_line_edit.text = autocomplete(text_before_caret())
 			set_line_edit_caret_to_end.call_deferred()
-		elif input_line_edit.caret_column == 0:
-			if event.keycode == KEY_UP:
-				input_line_edit.text = history_get_next()
-				set_line_edit_caret_to_beginning.call_deferred()
-			elif event.keycode == KEY_DOWN:
-				input_line_edit.text = history_get_previous()
-				set_line_edit_caret_to_beginning.call_deferred()
+	elif event.keycode == KEY_UP:
+		input_line_edit.text = history_get_next()
+		set_line_edit_caret_to_end.call_deferred()
+	elif event.keycode == KEY_DOWN:
+		input_line_edit.text = history_get_previous()
+		set_line_edit_caret_to_end.call_deferred()
 		else:
 			history_reset_index()
 		

--- a/addons/gdshell/ui/default_ui/default_ui.gd
+++ b/addons/gdshell/ui/default_ui/default_ui.gd
@@ -105,8 +105,6 @@ func _handle_output(output: String, append_new_line: bool = true) -> void:
 
 func _on_input_line_edit_text_submitted(input: String) -> void:
 	input_line_edit.clear()
-	history.push_front(input)
-	hist_index = -1
 	if _is_input_requested:
 		submit_input(input)
 		_is_input_requested = false
@@ -126,22 +124,28 @@ func _on_visibility_changed() -> void:
 	else:
 		input_line_edit.release_focus()
 
-var history: Array = []
-var hist_index = -1
-
 func set_line_edit_caret_to_end():
+	input_line_edit.grab_focus()
 	input_line_edit.caret_column = input_line_edit.text.length()
+
+func set_line_edit_caret_to_beginning():
+	input_line_edit.caret_column = 0
+	
+func text_before_caret() -> String:
+	return input_line_edit.text.substr(0, input_line_edit.caret_column)
 
 func _on_input_line_edit_gui_input(event):
 	if (event is InputEventKey and event.pressed):
 		if event.keycode == KEY_TAB:
-			input_line_edit.text = autocomplete(input_line_edit.text)
+			input_line_edit.text = autocomplete(text_before_caret())
 			set_line_edit_caret_to_end.call_deferred()
-		elif input_line_edit.caret_column == 0 and history.size() > 0:
+		elif input_line_edit.caret_column == 0:
 			if event.keycode == KEY_UP:
-				hist_index = clamp(hist_index + 1, 0, history.size() - 1)
-				input_line_edit.text = history[hist_index]
+				input_line_edit.text = history_get_next()
+				set_line_edit_caret_to_beginning.call_deferred()
 			elif event.keycode == KEY_DOWN:
-				hist_index = clamp(hist_index - 1, 0, history.size() - 1)
-				input_line_edit.text = history[hist_index]
+				input_line_edit.text = history_get_previous()
+				set_line_edit_caret_to_beginning.call_deferred()
+		else:
+			history_reset_index()
 		

--- a/addons/gdshell/ui/default_ui/default_ui.tscn
+++ b/addons/gdshell/ui/default_ui/default_ui.tscn
@@ -27,7 +27,7 @@ expand_margin_right = 3.0
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_b1ltg"]
 
 [node name="gdshell_ui_handler" type="PanelContainer"]
-custom_minimum_size = Vector2i(0, 100)
+custom_minimum_size = Vector2(0, 100)
 anchors_preset = -1
 anchor_right = 1.0
 anchor_bottom = 0.666667
@@ -38,48 +38,26 @@ metadata/_edit_use_anchors_ = true
 [node name="BackgroundPanel" type="Panel" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 1152.0
-offset_bottom = 432.0
-grow_horizontal = 2
-grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_hcxhe")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
-offset_right = 1152.0
-offset_bottom = 432.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
-offset_right = 1152.0
-offset_bottom = 432.0
-grow_horizontal = 2
-grow_vertical = 2
 size_flags_vertical = 3
 
 [node name="HSpacer0" type="Control" parent="VBoxContainer/HBoxContainer"]
-custom_minimum_size = Vector2i(3, 0)
+custom_minimum_size = Vector2(3, 0)
 layout_mode = 2
-anchors_preset = 0
-offset_right = 3.0
-offset_bottom = 432.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
-offset_left = 7.0
-offset_right = 1145.0
-offset_bottom = 432.0
-grow_horizontal = 2
-grow_vertical = 2
 size_flags_horizontal = 3
 
 [node name="OutputRichTextLabel" type="RichTextLabel" parent="VBoxContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 1138.0
-offset_bottom = 403.0
 size_flags_vertical = 3
 focus_mode = 2
 theme_override_fonts/normal_font = ExtResource("2_cto07")
@@ -93,11 +71,8 @@ selection_enabled = true
 
 [node name="InputBarPanel" type="Panel" parent="VBoxContainer/HBoxContainer/VBoxContainer"]
 unique_name_in_owner = true
-custom_minimum_size = Vector2i(0, 25)
+custom_minimum_size = Vector2(0, 25)
 layout_mode = 2
-offset_top = 407.0
-offset_right = 1138.0
-offset_bottom = 432.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_t83jw")
 
 [node name="InputHBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer/VBoxContainer/InputBarPanel"]
@@ -112,8 +87,6 @@ grow_vertical = 2
 [node name="InputPromptLabel" type="Label" parent="VBoxContainer/HBoxContainer/VBoxContainer/InputBarPanel/InputHBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 183.0
-offset_bottom = 25.0
 theme_override_fonts/font = ExtResource("2_cto07")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_atmjn")
 text = "gdshell@GDShell:~$ "
@@ -121,10 +94,9 @@ text = "gdshell@GDShell:~$ "
 [node name="InputLineEdit" type="LineEdit" parent="VBoxContainer/HBoxContainer/VBoxContainer/InputBarPanel/InputHBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 187.0
-offset_right = 1138.0
-offset_bottom = 25.0
 size_flags_horizontal = 3
+focus_next = NodePath(".")
+focus_previous = NodePath(".")
 theme_override_fonts/font = ExtResource("2_cto07")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_eg7qu")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_gepu6")
@@ -134,11 +106,8 @@ caret_blink = true
 caret_blink_interval = 0.5
 
 [node name="HSpacer1" type="Control" parent="VBoxContainer/HBoxContainer"]
-custom_minimum_size = Vector2i(3, 0)
+custom_minimum_size = Vector2(3, 0)
 layout_mode = 2
-anchors_preset = 0
-offset_left = 1149.0
-offset_right = 1152.0
-offset_bottom = 432.0
 
+[connection signal="gui_input" from="VBoxContainer/HBoxContainer/VBoxContainer/InputBarPanel/InputHBoxContainer/InputLineEdit" to="." method="_on_input_line_edit_gui_input"]
 [connection signal="text_submitted" from="VBoxContainer/HBoxContainer/VBoxContainer/InputBarPanel/InputHBoxContainer/InputLineEdit" to="." method="_on_input_line_edit_text_submitted"]

--- a/addons/gdshell/ui/default_ui/default_ui.tscn
+++ b/addons/gdshell/ui/default_ui/default_ui.tscn
@@ -33,6 +33,9 @@ anchor_right = 1.0
 anchor_bottom = 0.666667
 script = ExtResource("2_7mabp")
 input_prompt = "gdshell@GDShell:~$ "
+input_bar_color = Color(0.176471, 0.196078, 0.219608, 1)
+input_bar_uneditable_color = Color(0.145098, 0.168627, 0.203922, 1)
+background_color = Color(0.113725, 0.133333, 0.160784, 0.705882)
 metadata/_edit_use_anchors_ = true
 
 [node name="BackgroundPanel" type="Panel" parent="."]
@@ -95,8 +98,6 @@ text = "gdshell@GDShell:~$ "
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-focus_next = NodePath(".")
-focus_previous = NodePath(".")
 theme_override_fonts/font = ExtResource("2_cto07")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_eg7qu")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_gepu6")


### PR DESCRIPTION
This adds a very rudimentary history that you can navigate using the UP and DOWN arrows.
This is allowed only when the caret is at position 0.

I did not prevent UP and DOWN from going to the beginning of the line_edit and the end, respectively.
I like it like this but, we can easily change this I think.

History size is unlimited, I don't think this is going to be a problem.

Using the TAB key triggers autocompletion. The matching function is very simple as well, we could improve it, no doubt.

I added focus_next and focus_previous on the line_edit that point to itself to prevent focus loss... We could easily regrab focus instead.
We need a call deferred function to set the caret at the end anyway.

I'm not sure why there are more diff in the default_ui.tscn, this is not my doing :smile: 
I can revert it if convenient.

Anyway, love the plugin!
Waiting for your feedback!

NB: I'm relatively new to gdscript so feel free to point out my mistakes :wink: 